### PR TITLE
Allow crate names to contain dashes

### DIFF
--- a/src/bin/cargo_semver.rs
+++ b/src/bin/cargo_semver.rs
@@ -148,20 +148,21 @@ impl<'a> WorkInfo<'a> {
 fn do_main(config: &Config, matches: &Matches) -> CargoResult<()> {
     debug!("running cargo-semver");
     fn parse_arg(opt: &str) -> CargoResult<NameAndVersion> {
-        let mut split = opt.split('-');
+        let mut split = opt.split('=');
         let name = if let Some(n) = split.next() {
-            n
+            // Trim so 'name = version' works
+            n.trim_right()
         } else {
-            return Err("spec has to be of form `name-version`".into());
+            return Err("spec has to be of form `name=version`".into());
         };
         let version = if let Some(v) = split.next() {
-            v
+            v.trim_left()
         } else {
-            return Err("spec has to be of form `name-version`".into());
+            return Err("spec has to be of form `name=version`".into());
         };
 
         if split.next().is_some() {
-            return Err("spec has to be of form `name-version`".into());
+            return Err("spec has to be of form `name=version`".into());
         }
 
         Ok(NameAndVersion { name: name, version: version })
@@ -270,9 +271,9 @@ fn main() {
     opts.optflag("d", "debug", "print command to debug and exit");
     opts.optopt("s", "stable-path", "use local path as stable/old crate", "PATH");
     opts.optopt("c", "current-path", "use local path as current/new crate", "PATH");
-    opts.optopt("S", "stable-pkg", "use a name-version string as stable/old crate",
+    opts.optopt("S", "stable-pkg", "use a name=version string as stable/old crate",
                 "SPEC");
-    opts.optopt("C", "current-pkg", "use a name-version string as current/new crate",
+    opts.optopt("C", "current-pkg", "use a name=version string as current/new crate",
                 "SPEC");
 
     let config = match Config::default() {

--- a/tests/full.rs
+++ b/tests/full.rs
@@ -10,8 +10,8 @@ macro_rules! full_test {
         fn $name() {
             let mut success = true;
 
-            let old_version = concat!($crate_name, "-", $old_version);
-            let new_version = concat!($crate_name, "-", $new_version);
+            let old_version = concat!($crate_name, "=", $old_version);
+            let new_version = concat!($crate_name, "=", $new_version);
 
             let prog = concat!(r#"
 # wait for the actual output
@@ -29,7 +29,7 @@ macro_rules! full_test {
     print;
 }"#, $crate_name, $crate_name);
             let out_file = Path::new("tests/full_cases")
-                .join(concat!($crate_name, "-", $old_version, "-", $new_version));
+                .join(concat!($crate_name, "=", $old_version, "=", $new_version));
 
             if let Some(path) = env::var_os("PATH") {
                 let mut paths = env::split_paths(&path).collect::<Vec<_>>();


### PR DESCRIPTION
name-version doesn't work because crate names can contain dashes. Instead, separate with an `=`.