### PR TITLE
Fixed build with nightly.

### DIFF
--- a/src/bin/rust_semverver.rs
+++ b/src/bin/rust_semverver.rs
@@ -9,13 +9,14 @@ extern crate rustc;
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_codegen_utils;
+extern crate rustc_metadata;
 extern crate semverver;
 extern crate syntax;
 
 use semverver::semcheck::run_analysis;
 
 use rustc::hir::def_id::*;
-use rustc::middle::cstore::CrateStore;
+use rustc_metadata::cstore::CStore;
 use rustc::session::{config, Session};
 use rustc::session::config::{Input, ErrorOutputType};
 
@@ -128,7 +129,7 @@ impl<'a> CompilerCalls<'a> for SemVerVerCompilerCalls {
                      trans_crate: &CodegenBackend,
                      matches: &getopts::Matches,
                      sess: &Session,
-                     cstore: &CrateStore,
+                     cstore: &CStore,
                      input: &Input,
                      odir: &Option<PathBuf>,
                      ofile: &Option<PathBuf>)

--- a/src/semcheck/mapping.rs
+++ b/src/semcheck/mapping.rs
@@ -321,7 +321,8 @@ impl NameMapping {
             AssociatedExistential(_) |
             PrimTy(_) |
             TyParam(_) |
-            SelfTy(_, _) => Some(&mut self.type_map),
+            SelfTy(_, _) |
+            ToolMod => Some(&mut self.type_map),
             Fn(_) |
             Const(_) |
             Static(_, _) |
@@ -332,8 +333,8 @@ impl NameMapping {
             Local(_) |
             Upvar(_, _, _) |
             Label(_) => Some(&mut self.value_map),
-            Macro(_, _) => Some(&mut self.macro_map),
-            GlobalAsm(_) |
+            Macro(_, _) |
+            NonMacroAttr(_) => Some(&mut self.macro_map),
             Err => None,
         };
 

--- a/src/semcheck/traverse.rs
+++ b/src/semcheck/traverse.rs
@@ -174,7 +174,6 @@ fn diff_structure<'a, 'tcx>(changes: &mut ChangeSet,
                             (Local(_), Local(_)) |
                             (Upvar(_, _, _), Upvar(_, _, _)) |
                             (Label(_), Label(_)) |
-                            (GlobalAsm(_), GlobalAsm(_)) |
                             (Macro(_, _), Macro(_, _)) |
                             (Variant(_), Variant(_)) |
                             (Const(_), Const(_)) |


### PR DESCRIPTION
CrateStore trait -> CStore struct in the `late_callback`, and some added/removed variants in `rustc::hir::def::Def`.

Compiles, but does not work properly because of #64.